### PR TITLE
chore: update dev dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-var parseMs = require('parse-ms')
-var addZero = require('add-zero')
+const parseMs = require('parse-ms')
+const addZero = require('add-zero')
 
 module.exports = function (ms, options) {
-  var leading = options && options.leading
-  var unsignedMs = ms < 0 ? -ms : ms
-  var sign = ms <= -1000 ? '-' : ''
-  var t = parseMs(unsignedMs)
-  var seconds = addZero(t.seconds)
+  const leading = options && options.leading
+  const unsignedMs = ms < 0 ? -ms : ms
+  const sign = ms <= -1000 ? '-' : ''
+  const t = parseMs(unsignedMs)
+  const seconds = addZero(t.seconds)
   if (t.days) return sign + t.days + ':' + addZero(t.hours) + ':' + addZero(t.minutes) + ':' + seconds
   if (t.hours) return sign + (leading ? addZero(t.hours) : t.hours) + ':' + addZero(t.minutes) + ':' + seconds
   return sign + (leading ? addZero(t.minutes) : t.minutes) + ':' + seconds

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "is-es5": "^1.0.0",
     "standard": "^16.0.4",
-    "tape": "^4.0.0"
+    "tape": "^5.5.2"
   },
   "homepage": "https://github.com/hypermodules/format-duration",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "devDependencies": {
     "is-es5": "^1.0.0",
     "standard": "^11.0.1",
-    "tap-spec": "^5.0.0",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/hypermodules/format-duration",
@@ -36,6 +35,6 @@
     "url": "git+https://github.com/hypermodules/format-duration.git"
   },
   "scripts": {
-    "test": "standard && tape test/index.js | tap-spec"
+    "test": "standard && tape test/index.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "is-es5": "^1.0.0",
-    "standard": "^11.0.1",
+    "standard": "^16.0.4",
     "tape": "^4.0.0"
   },
   "homepage": "https://github.com/hypermodules/format-duration",

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
-var test = require('tape')
-var fs = require('fs')
-var path = require('path')
-var isES5 = require('is-es5')
-var f = require('../')
-var src = fs.readFileSync(path.join(__dirname, '../index.js'), 'utf-8')
+const test = require('tape')
+const fs = require('fs')
+const path = require('path')
+const isES5 = require('is-es5')
+const f = require('../')
+const src = fs.readFileSync(path.join(__dirname, '../index.js'), 'utf-8')
 
 test('it works', function (t) {
   t.equal(f(999), '0:00', 'anything under a second is 0:00')


### PR DESCRIPTION
**BREAKING CHANGE**: this updates standard to 16, which includes switching to using const and let instead of var.

A future PR will officially drop support for node 8 & 10 and target current LTS (12, 14, 16).

The next release will be 2.0.0.