### PR TITLE
feat: adapt code from parse-ms & add-zero

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,42 @@
-const parseMs = require('parse-ms')
-const addZero = require('add-zero')
+// adapted from https://github.com/sindresorhus/parse-ms.
+// moved to internal function because parse-ms is now pure ESM.
+function parseMs (milliseconds) {
+  if (typeof milliseconds !== 'number') {
+    throw new TypeError('Expected a number')
+  }
 
-module.exports = function (ms, options) {
+  return {
+    days: Math.trunc(milliseconds / 86400000),
+    hours: Math.trunc(milliseconds / 3600000) % 24,
+    minutes: Math.trunc(milliseconds / 60000) % 60,
+    seconds: Math.trunc(milliseconds / 1000) % 60,
+    milliseconds: Math.trunc(milliseconds) % 1000
+  }
+}
+
+// adapted from https://github.com/rafaelrinaldi/add-zero.
+// moved to internal function b/c addZero is unmaintained (7+ years).
+// stripped out negative sign logic since we're already doing it elsewhere.
+function addZero (value, digits) {
+  digits = digits || 2
+
+  let str = value.toString()
+  let size = 0
+
+  size = digits - str.length + 1
+  str = new Array(size).join('0').concat(str)
+
+  return str
+}
+
+/**
+ * Convert a number in milliseconds to a standard duration string.
+ * @param {number} ms - duration in milliseconds
+ * @param {object} options - formatDuration options object
+ * @param {boolean} [options.leading=false] - add leading zero
+ * @returns string - formatted duration string
+ */
+function formatDuration (ms, options) {
   const leading = options && options.leading
   const unsignedMs = ms < 0 ? -ms : ms
   const sign = ms <= -1000 ? '-' : ''
@@ -11,3 +46,5 @@ module.exports = function (ms, options) {
   if (t.hours) return sign + (leading ? addZero(t.hours) : t.hours) + ':' + addZero(t.minutes) + ':' + seconds
   return sign + (leading ? addZero(t.minutes) : t.minutes) + ':' + seconds
 }
+
+module.exports = formatDuration

--- a/package.json
+++ b/package.json
@@ -6,10 +6,6 @@
   "bugs": {
     "url": "https://github.com/ungoldman/format-duration/issues"
   },
-  "dependencies": {
-    "add-zero": "^1.0.0",
-    "parse-ms": "^1.0.1"
-  },
   "devDependencies": {
     "standard": "^16.0.4",
     "tape": "^5.5.2"


### PR DESCRIPTION
## summary

- remove `parse-ms` and `add-zero` deps
- adapt code from both to internal functions

**Result:** format-duration now has zero dependencies!

## why?

`parse-ms` is now pure ESM, which is not backwards compatible with the majority of node modules currently in use.

`add-zero` hasn't been updated in 7 years and is therefore effectively unmaintained.

Both modules are very small and only export a single function.

Rather than continuing to rely on old versions of modules, it is simpler to copy what is needed, trim unneeded code, and maintain these functions internally.

## further reading

Using the reasoning of this issue (though both above are a bit more than 10 lines; 15 and 32 respectively): https://socket.dev/npm/issue/trivialPackage