### PR TITLE
Added msDigits option to limit how many milisecond digits are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ format(1000 * 60 * 60, { leading: true }) // '01:00:00'
 format(999, { ms: true }) // '0:00.999'
 format(1000 * 60, { ms: true }) // '1:00.000'
 format(1000 * 60 * 60 * 24 - 1, { ms: true }) // '23:59:59.999'
+
+// with `msDigits` option, formatting looks like this
+format(999, { ms: true, msDigits: 2 }) // '0:00.99'
+format(1000 * 60, { ms: true, msDigits: 1 }) // '1:00.0'
+format(1000 * 60 * 60 * 24 - 1, { ms: true, msDigits: 4 }) // '23:59:59.999'
 ```
 
 ## Contributing

--- a/format-duration.d.ts
+++ b/format-duration.d.ts
@@ -4,8 +4,12 @@ declare namespace formatDuration {
      * Adds leading zero to the formatted string.
      */
     leading?: boolean
+  } & ({
     ms?: boolean
-  }
+  } | {
+    ms: boolean
+    msDigits?: number
+  })
 }
 
 /**

--- a/format-duration.js
+++ b/format-duration.js
@@ -55,7 +55,7 @@ function formatDuration (ms, options) {
   if (t.hours && !output) output = sign + (leading ? addZero(t.hours) : t.hours) + ':' + addZero(t.minutes) + ':' + seconds
   if (!output) output = sign + (leading ? addZero(t.minutes) : t.minutes) + ':' + seconds
 
-  if (showMs) output += '.' + addZero(t.ms, 3)
+  if (showMs) output += '.' + addZero(t.ms, 3).substring(0, options.msDigits !== undefined ? options.msDigits : 3)
   return output
 }
 

--- a/format-duration.test.js
+++ b/format-duration.test.js
@@ -12,6 +12,7 @@ test('it works', function (t) {
   t.equal(f(1000 * 60 * 60 * 24), '1:00:00:00', 'check 24 hours is a day')
   t.equal(f(1000 * 60 * 60 * 24 - 1), '23:59:59', 'check 23 hours looks okay')
   t.equal(f(1000 * 60 * 60 * 24 * 365), '365:00:00:00', 'check 365 days is too long to care')
+  t.equal(f(1000 * 60 * 60 - 1, { ms: true, msDigits: 2 }), '59:59.00', 'check msDigits limits ms digits')
   t.end()
 })
 


### PR DESCRIPTION
Sometimes (e.g. some kind of stopwatch timers) you might want to display only 2 millisecond digits instead of the full 3 so this option should be nicer than doing something like:

```typescript
const msAmount = 1000 * 60 * 60 - 1;

const fDur = format(msAmount, { ms: true });

// Old way
const formatted = format(msAmount, { ms:true });
const oldWay = formatted.substring(0, formatted.length - 1);

// New way
const newWay = format(msAmount, { ms: true, msDigits: 2 });
```